### PR TITLE
Refs [TASK][37098] Data Home Screen(Part2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     //Retrofit2
     implementation "com.squareup.retrofit2:retrofit:$retrofit2_version"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit2_version"
+    implementation 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
     // ViewModel
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version")
     // LiveData

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.sunasterisk.loltournaments">
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:name=".LolApplication"

--- a/app/src/main/java/com/sunasterisk/loltournaments/LolApplication.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/LolApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.sunasterisk.loltournaments.di.databaseModule
 import com.sunasterisk.loltournaments.di.networkModule
 import com.sunasterisk.loltournaments.di.sourceModule
+import com.sunasterisk.loltournaments.di.viewModelModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
@@ -12,7 +13,7 @@ class LolApplication: Application() {
         super.onCreate()
         startKoin {
             androidContext(this@LolApplication)
-            modules(listOf(networkModule, databaseModule, sourceModule))
+            modules(listOf(networkModule, databaseModule, sourceModule, viewModelModule))
         }
     }
 }

--- a/app/src/main/java/com/sunasterisk/loltournaments/base/BaseViewModel.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/base/BaseViewModel.kt
@@ -13,5 +13,6 @@ abstract class BaseViewModel : ViewModel() {
 
     val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         _error.postValue(throwable.message)
+        _isLoading.postValue(false)
     }
 }

--- a/app/src/main/java/com/sunasterisk/loltournaments/data/model/remote/Serie.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/data/model/remote/Serie.kt
@@ -1,5 +1,7 @@
 package com.sunasterisk.loltournaments.data.model.remote
 
+import android.graphics.drawable.Drawable
+import androidx.recyclerview.widget.DiffUtil
 import com.google.gson.annotations.SerializedName
 
 data class Serie(
@@ -20,4 +22,18 @@ data class Serie(
     @SerializedName("winner_id")
     val winnerId: Int,
     val year: Int
-)
+) {
+    var background: Int? = null
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<Serie>() {
+            override fun areItemsTheSame(oldItem: Serie, newItem: Serie): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(oldItem: Serie, newItem: Serie): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/sunasterisk/loltournaments/ui/adapter/SerieAdapter.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/ui/adapter/SerieAdapter.kt
@@ -1,0 +1,64 @@
+package com.sunasterisk.loltournaments.ui.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import com.sunasterisk.loltournaments.R
+import com.sunasterisk.loltournaments.base.BaseAdapter
+import com.sunasterisk.loltournaments.base.BaseViewHolder
+import com.sunasterisk.loltournaments.data.model.remote.Serie
+import com.sunasterisk.loltournaments.databinding.ItemSerieBinding
+
+class SerieAdapter(
+    private val onItemClick: (Serie) -> Unit
+) : BaseAdapter<Serie, SerieAdapter.ViewHolder>(Serie.diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ViewHolder(
+        DataBindingUtil.inflate(
+            LayoutInflater.from(parent.context),
+            R.layout.item_serie,
+            parent,
+            false
+        ),
+        onItemClick
+    )
+
+    class ViewHolder(
+        private val binding: ItemSerieBinding,
+        onItemClick: (Serie) -> Unit
+    ) : BaseViewHolder<Serie>(binding, onItemClick) {
+        override fun onBind(item: Serie) {
+            super.onBind(item)
+            item.background = when (adapterPosition % BACKGROUND_COUNT) {
+                POSITION_0 -> R.drawable.serie_background_1
+                POSITION_1 -> R.drawable.serie_background_2
+                POSITION_2 -> R.drawable.serie_background_3
+                POSITION_3 -> R.drawable.serie_background_4
+                POSITION_4 -> R.drawable.serie_background_5
+                POSITION_5 -> R.drawable.serie_background_6
+                POSITION_6 -> R.drawable.serie_background_7
+                POSITION_7 -> R.drawable.serie_background_8
+                POSITION_8 -> R.drawable.serie_background_9
+                POSITION_9 -> R.drawable.serie_background_10
+                else -> R.drawable.serie_background_1
+            }
+
+            item.background?.let { binding.imageSerie.setImageResource(it) }
+            binding.serie = item
+        }
+    }
+
+    companion object {
+        const val POSITION_0 = 0
+        const val POSITION_1 = 1
+        const val POSITION_2 = 2
+        const val POSITION_3 = 3
+        const val POSITION_4 = 4
+        const val POSITION_5 = 5
+        const val POSITION_6 = 6
+        const val POSITION_7 = 7
+        const val POSITION_8 = 8
+        const val POSITION_9 = 9
+        const val BACKGROUND_COUNT = 10
+    }
+}

--- a/app/src/main/java/com/sunasterisk/loltournaments/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/ui/home/HomeFragment.kt
@@ -2,15 +2,13 @@ package com.sunasterisk.loltournaments.ui.home
 
 import android.view.View
 import android.widget.AdapterView
-import androidx.core.view.isEmpty
-import androidx.core.view.isNotEmpty
 import androidx.lifecycle.Observer
 import com.sunasterisk.loltournaments.R
 import com.sunasterisk.loltournaments.base.BaseFragment
 import com.sunasterisk.loltournaments.data.source.remote.*
 import com.sunasterisk.loltournaments.databinding.FragmentHomeBinding
-import com.sunasterisk.loltournaments.ui.adapter.ViewPagerAdapter
 import com.sunasterisk.loltournaments.ui.adapter.LeagueAdapter
+import com.sunasterisk.loltournaments.ui.adapter.ViewPagerAdapter
 import kotlinx.android.synthetic.main.fragment_home.*
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 
@@ -18,6 +16,9 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     override val layoutResource = R.layout.fragment_home
     override val viewModel by sharedViewModel<HomeViewModel>()
 
+    private val fragmentSerieCompleted = SerieCompletedFragment()
+    private val fragmentSerieRunning = SerieRunningFragment()
+    private val fragmentSerieUpcoming = SerieUpcomingFragment()
     private val leagueAdapter by lazy { context?.let { LeagueAdapter(it) } }
     private val leagueIds = listOf(
         LCK_LEAGUE_ID,
@@ -31,6 +32,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
 
     override fun initViews() {
         initSpinnerLeague()
+        initTabLayoutWithViewPager()
     }
 
     override fun initData() {
@@ -58,8 +60,18 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         }
 
         viewModel.leagues.observe(viewLifecycleOwner, Observer {
-            if(spinnerLeague.count != it.size) leagueAdapter?.setData(it)
+            if (spinnerLeague.count != it.size) leagueAdapter?.setData(it)
         })
+    }
+
+    private fun initTabLayoutWithViewPager() {
+        val homeViewPagerAdapter = ViewPagerAdapter(childFragmentManager)
+        homeViewPagerAdapter.addFragment(fragmentSerieCompleted, getString(R.string.title_completed))
+        homeViewPagerAdapter.addFragment(fragmentSerieRunning, getString(R.string.title_running))
+        homeViewPagerAdapter.addFragment(fragmentSerieUpcoming, getString(R.string.title_upcoming))
+
+        pagerSeries.adapter = homeViewPagerAdapter
+        tabSeries.setupWithViewPager(pagerSeries)
     }
 
     private fun initSpinnerLeague() {

--- a/app/src/main/java/com/sunasterisk/loltournaments/ui/home/SerieCompletedFragment.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/ui/home/SerieCompletedFragment.kt
@@ -1,0 +1,29 @@
+package com.sunasterisk.loltournaments.ui.home
+
+import com.sunasterisk.loltournaments.R
+import com.sunasterisk.loltournaments.base.BaseFragment
+import com.sunasterisk.loltournaments.data.model.remote.Serie
+import com.sunasterisk.loltournaments.databinding.FragmentSerieCompletedBinding
+import com.sunasterisk.loltournaments.ui.adapter.SerieAdapter
+import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+
+class SerieCompletedFragment : BaseFragment<FragmentSerieCompletedBinding>() {
+    override val layoutResource = R.layout.fragment_serie_completed
+    override val viewModel by sharedViewModel<HomeViewModel>()
+
+    override fun initViews() {}
+
+    override fun initData() {
+        val serieAdapter = SerieAdapter(this::onSerieClick)
+        binding?.apply {
+            lifecycleOwner = viewLifecycleOwner
+            serieViewModel = viewModel
+            recyclerSeriesCompleted.adapter = serieAdapter
+        }
+    }
+
+    override fun initActions() {}
+
+    private fun onSerieClick(serie: Serie) {
+    }
+}

--- a/app/src/main/java/com/sunasterisk/loltournaments/ui/home/SerieRunningFragment.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/ui/home/SerieRunningFragment.kt
@@ -1,0 +1,29 @@
+package com.sunasterisk.loltournaments.ui.home
+
+import com.sunasterisk.loltournaments.R
+import com.sunasterisk.loltournaments.base.BaseFragment
+import com.sunasterisk.loltournaments.data.model.remote.Serie
+import com.sunasterisk.loltournaments.databinding.FragmentSerieRunningBinding
+import com.sunasterisk.loltournaments.ui.adapter.SerieAdapter
+import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+
+class SerieRunningFragment : BaseFragment<FragmentSerieRunningBinding>() {
+    override val layoutResource = R.layout.fragment_serie_running
+    override val viewModel by sharedViewModel<HomeViewModel>()
+
+    override fun initViews() {}
+
+    override fun initData() {
+        val serieAdapter = SerieAdapter(this::onSerieClick)
+        binding?.apply {
+            lifecycleOwner = viewLifecycleOwner
+            serieViewModel = viewModel
+            recyclerSeriesCompleted.adapter = serieAdapter
+        }
+    }
+
+    override fun initActions() {}
+
+    private fun onSerieClick(serie: Serie) {
+    }
+}

--- a/app/src/main/java/com/sunasterisk/loltournaments/ui/home/SerieUpcomingFragment.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/ui/home/SerieUpcomingFragment.kt
@@ -1,0 +1,29 @@
+package com.sunasterisk.loltournaments.ui.home
+
+import com.sunasterisk.loltournaments.R
+import com.sunasterisk.loltournaments.base.BaseFragment
+import com.sunasterisk.loltournaments.data.model.remote.Serie
+import com.sunasterisk.loltournaments.databinding.FragmentSerieUpcomingBinding
+import com.sunasterisk.loltournaments.ui.adapter.SerieAdapter
+import org.koin.androidx.viewmodel.ext.android.sharedViewModel
+
+class SerieUpcomingFragment : BaseFragment<FragmentSerieUpcomingBinding>() {
+    override val layoutResource = R.layout.fragment_serie_upcoming
+    override val viewModel by sharedViewModel<HomeViewModel>()
+
+    override fun initViews() {}
+
+    override fun initData() {
+        val serieAdapter = SerieAdapter(this::onSerieClick)
+        binding?.apply {
+            lifecycleOwner = viewLifecycleOwner
+            serieViewModel = viewModel
+            recyclerSeriesCompleted.adapter = serieAdapter
+        }
+    }
+
+    override fun initActions() {}
+
+    private fun onSerieClick(serie: Serie) {
+    }
+}

--- a/app/src/main/java/com/sunasterisk/loltournaments/ultils/ImageViewExtensions.kt
+++ b/app/src/main/java/com/sunasterisk/loltournaments/ultils/ImageViewExtensions.kt
@@ -1,0 +1,11 @@
+package com.sunasterisk.loltournaments.ultils
+
+import android.widget.ImageView
+import androidx.databinding.BindingAdapter
+import com.bumptech.glide.Glide
+import com.sunasterisk.loltournaments.R
+
+@BindingAdapter("loadImageUrl")
+fun ImageView.loadImage(url: String) {
+    Glide.with(this).load(url).placeholder(R.drawable.ic_placeholder).into(this)
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -29,6 +29,8 @@
             android:id="@+id/spinnerLeague"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:layout_marginStart="@dimen/dp_5"
+            android:layout_marginEnd="@dimen/dp_10"
             android:background="@drawable/spinner_league_background"
             android:popupBackground="@drawable/square_radius"
             app:layout_constraintBottom_toBottomOf="@+id/imageToolbar"
@@ -38,9 +40,10 @@
 
         <ImageView
             android:id="@+id/imageNotify"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:layout_margin="@dimen/dp_16"
+            android:layout_width="@dimen/dp_20"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/dp_16"
+            android:layout_marginEnd="@dimen/dp_10"
             android:src="@drawable/ic_notify"
             app:layout_constraintBottom_toBottomOf="@+id/imageToolbar"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_serie_completed.xml
+++ b/app/src/main/res/layout/fragment_serie_completed.xml
@@ -5,13 +5,17 @@
 
     <data>
 
+        <variable
+            name="serieViewModel"
+            type="com.sunasterisk.loltournaments.ui.home.HomeViewModel" />
     </data>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerSeriesCompleted"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:clipToPadding="false"
+        android:data="@{serieViewModel.serieCompleted}"
         android:paddingHorizontal="@dimen/dp_5"
         android:paddingTop="@dimen/dp_5"
         android:paddingBottom="@dimen/dp_50"

--- a/app/src/main/res/layout/fragment_serie_running.xml
+++ b/app/src/main/res/layout/fragment_serie_running.xml
@@ -5,6 +5,10 @@
 
     <data>
 
+        <variable
+            name="serieViewModel"
+            type="com.sunasterisk.loltournaments.ui.home.HomeViewModel" />
+        <import type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -16,6 +20,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:clipToPadding="false"
+            android:data="@{serieViewModel.serieRunning}"
             android:paddingHorizontal="@dimen/dp_5"
             android:paddingTop="@dimen/dp_5"
             android:paddingBottom="@dimen/dp_50"
@@ -33,6 +38,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="@dimen/dp_100"
             android:src="@drawable/ic_empty"
+            android:visibility="@{serieViewModel.serieRunning.size() > 0 ? View.GONE : View.VISIBLE}"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -44,6 +50,7 @@
             android:text="@string/text_empty_series"
             android:textColor="@color/color_blumine"
             android:textSize="@dimen/sp_20"
+            android:visibility="@{serieViewModel.serieRunning.size() > 0 ? View.GONE : View.VISIBLE}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/imageEmpty" />

--- a/app/src/main/res/layout/fragment_serie_upcoming.xml
+++ b/app/src/main/res/layout/fragment_serie_upcoming.xml
@@ -5,6 +5,11 @@
 
     <data>
 
+        <variable
+            name="serieViewModel"
+            type="com.sunasterisk.loltournaments.ui.home.HomeViewModel" />
+
+        <import type="android.view.View" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -16,6 +21,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:clipToPadding="false"
+            android:data="@{serieViewModel.serieUpcoming}"
             android:paddingHorizontal="@dimen/dp_5"
             android:paddingTop="@dimen/dp_5"
             android:paddingBottom="@dimen/dp_50"
@@ -33,6 +39,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="@dimen/dp_100"
             android:src="@drawable/ic_empty"
+            android:visibility="@{serieViewModel.serieUpcoming.size() > 0 ? View.GONE : View.VISIBLE}"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -44,6 +51,7 @@
             android:text="@string/text_empty_series"
             android:textColor="@color/color_blumine"
             android:textSize="@dimen/sp_20"
+            android:visibility="@{serieViewModel.serieUpcoming.size() > 0 ? View.GONE : View.VISIBLE}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/imageEmpty" />

--- a/app/src/main/res/layout/item_league.xml
+++ b/app/src/main/res/layout/item_league.xml
@@ -16,6 +16,7 @@
 
         <ImageView
             android:id="@+id/imageLeague"
+            loadImageUrl="@{league.imageUrl}"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:padding="@dimen/dp_10"


### PR DESCRIPTION
## Related Tickets
- [#Task 37098: Data Home Screen](https://edu-redmine.sun-asterisk.vn/issues/37098)
## WHAT
- 
## Evidence (Screenshot or Video)

## Review Checklist

Category | View Point | Description | Self review | Reviewer2 (name)
--- | --- | --- | --- | ---
Conventions | Sun* coding conventions | https://github.com/framgia/coding-standards/tree/master/eng/android |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Conventions | Kotlin coding conventions | https://kotlinlang.org/docs/coding-conventions.html |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Sun* Redmine working process  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md |<li>- [ ] yes</li>|<li>- [ ] yes</li>  

## Notes (Optional)
*(Impacted Areas in Application(List features, api, models or services that this PR will affect))*

*(List gem, library third party add new)*

*(Other notes)*
